### PR TITLE
localization of date/time for MacOS

### DIFF
--- a/src/main.pas
+++ b/src/main.pas
@@ -15,7 +15,7 @@ uses
   projecttree_form, commandtree_form, stat_dialog_contribution, stat_dialog_action,
   script_runner, stat_dialog,
   {$IFDEF DARWIN}
-  CFPreferences, CFString, CocoaAll,
+  CFPreferences, CFString, CocoaAll, iosxlocale,
   {$ENDIF}
   {$IFDEF EPI_CHROMIUM_HTML}
   htmlviewer, htmlviewer_osr,


### PR DESCRIPTION
We must use unit *iosxlocale* (anywhere, but I put it in _main.pas_) to correctly get local formatting on MacOS.
However, there is a bug in FPC or Lazarus that treats yyyy as yy 
Similar change required for *NIX, but not done as I can't test it