### PR TITLE
Jamie/fix graphs

### DIFF
--- a/src/graph/commands/barchart/barchart.pas
+++ b/src/graph/commands/barchart/barchart.pas
@@ -110,111 +110,116 @@ begin
 
   yPct := Command.HasOption('pct');
 
-  DataFile := FExecutor.PrepareDatafile(DFVars, DFVars);
-  XVar := Datafile.Fields.FieldByName[VarNames[0]];
-  Chart := FChartFactory.NewChart();
-  BarSource := TBarSource.Create(Chart);
-  BarSource.Pct := yPct;
-  LabelSeries := TListChartSource.Create(Chart);
-  if (Varnames.Count = 1) then
-// add dummy variable to use Tables with one variable plus weight variable
-    begin
-      dummyVar := DataFile.NewField(ftInteger);
-      dummyVar.Name := dummyVarName;
-      Varnames.Add(dummyVarName);
-    end;
-// Note: this does NOT call CalcTables with stratification
-  T := TTables.Create(FExecutor, FOutputCreator);
-  TablesAll  := T.CalcTables(Datafile, VarNames,
-                StratVariable, WeightVarName, cOptions, nilTablesRefMap);
-  TableData := TablesAll.UnstratifiedTable;
-  if (ReverseStrata) then
-    TableData.SortByRowLabel(true);
-  BarSource.SetSource(TableData, ValueLabelOutput);
-
-  ByVarName := Datafile.Fields.FieldByName[VarNames[1]].GetVariableLabel(VariableLabelOutput);
-  for i := 0 to TableData.ColCount - 1 do
-    LabelSeries.Add(i.ToDouble, 0, TableData.ColVariable.GetValueLabelFormatted(i, ValueLabelOutput));
-
-  if (Varnames.IndexOf(dummyVarName) > -1) then
-    Varnames.Delete(Varnames.IndexOf(dummyVarName));
-
-  BarSeries := TBarSeries.Create(Chart);
-  BarSeries.Source := BarSource;
-  BarSeries.Stacked := cOptions.HasOption('stack');
-  BarSeries.BarWidthPercent := 80;
-  SeriesStyles := TChartStyles.Create(Chart);
-  if (Varnames.Count > 1) then
-    begin
-      colourNum := 0;
-      for i := 0 to TableData.RowCount - 1 do
-        begin
-          if (colourNum = length(sColor)) then
-            colourNum := 0;
-          aStyle := SeriesStyles.Add;
-          aStyle.Text := TableData.RowVariable.GetValueLabelFormatted(i, ValueLabelOutput);
-          aStyle.Brush.Color:=sColor[colourNum];
-          aStyle.Pen.Color := clSilver;
-          colourNum += 1;
-        end;
-      BarSeries.Legend.Multiplicity:=lmStyle;
-      BarSeries.Legend.GroupIndex  := 0;
-
-      Chart.Legend.Visible        := true;
-      Chart.Legend.UseSidebar     := true;
-      Chart.Legend.Frame.Visible  := false;
-      Chart.Legend.GroupTitles.Add(ByVarName);
-    end  // stratified
-  else
-    begin
-      aStyle := SeriesStyles.Add;
-      aStyle.Brush.Color := sColor[0];
-      aStyle.Pen.Color := clSilver;
-    end;
-    BarSeries.Styles := SeriesStyles;
-
-  // Add series to the chart
-  Chart.AddSeries(BarSeries);
-
-  if (yPct) then
-    yType := 'Percent'
-  else
-    yType := 'Count';
-  sTitle := yType + ' by ' + XVar.GetVariableLabel(VariableLabelOutput);
-  if (Varnames.Count > 1) then
-    sTitle += ' by ' + ByVarName;
-  if (WeightVarName <> '') then
-    sTitle += ' weighted (' + WeightVarName + ')';
-
-  VariableLabelOutput := VariableLabelTypeFromOptionList(cOptions, FExecutor.SetOptions, sovStatistics);
-  ChartConfiguration := FChartFactory.NewChartConfiguration();
-  ChartConfiguration.GetTitleConfiguration()
-    .SetTitle(sTitle)
-    .SetFootnote('')
-    .SetXAxisTitle(XVar.GetVariableLabel(VariableLabelOutput))
-    .SetYAxisTitle(yType);
-
-  ChartConfiguration.GetAxesConfiguration()
-    .GetXAxisConfiguration()
-    .SetShowAxisMarksAsDates(XVar.FieldType in DateFieldTypes);
-
-  with Chart do
-    begin
-      BottomAxis.Marks.Source := LabelSeries;
-      BottomAxis.Marks.Style  := smsLabel;
-      BottomAxis.Grid.Style   := psClear;
-      BottomAxis.Margin       := 0;
-      LeftAxis.Grid.Style     := psClear;
-      LeftAxis.Margin         := 0;
-      Frame.Visible           := false;
-    end;
-
   // Create the command result
   Result := FChartFactory.NewGraphCommandResult();
-  Result.AddChart(Chart, ChartConfiguration);
-  VarNames.Free;
-  TablesAll.Free;
-  T.Free;
+  DataFile := FExecutor.PrepareDatafile(DFVars, DFVars);
+  if (DataFile.Size < 1) then
+    FExecutor.Error('No data')
+  else
+  begin // create chart
+    XVar := Datafile.Fields.FieldByName[VarNames[0]];
+    Chart := FChartFactory.NewChart();
+    BarSource := TBarSource.Create(Chart);
+    BarSource.Pct := yPct;
+    LabelSeries := TListChartSource.Create(Chart);
+    if (Varnames.Count = 1) then
+  // add dummy variable to use Tables with one variable plus weight variable
+      begin
+        dummyVar := DataFile.NewField(ftInteger);
+        dummyVar.Name := dummyVarName;
+        Varnames.Add(dummyVarName);
+      end;
+  // Note: this does NOT call CalcTables with stratification
+    T := TTables.Create(FExecutor, FOutputCreator);
+    TablesAll  := T.CalcTables(Datafile, VarNames,
+                  StratVariable, WeightVarName, cOptions, nilTablesRefMap);
+    TableData := TablesAll.UnstratifiedTable;
+    if (ReverseStrata) then
+      TableData.SortByRowLabel(true);
+    BarSource.SetSource(TableData, ValueLabelOutput);
+
+    ByVarName := Datafile.Fields.FieldByName[VarNames[1]].GetVariableLabel(VariableLabelOutput);
+    for i := 0 to TableData.ColCount - 1 do
+      LabelSeries.Add(i.ToDouble, 0, TableData.ColVariable.GetValueLabelFormatted(i, ValueLabelOutput));
+
+    if (Varnames.IndexOf(dummyVarName) > -1) then
+      Varnames.Delete(Varnames.IndexOf(dummyVarName));
+
+    BarSeries := TBarSeries.Create(Chart);
+    BarSeries.Source := BarSource;
+    BarSeries.Stacked := cOptions.HasOption('stack');
+    BarSeries.BarWidthPercent := 80;
+    SeriesStyles := TChartStyles.Create(Chart);
+    if (Varnames.Count > 1) then
+      begin
+        colourNum := 0;
+        for i := 0 to TableData.RowCount - 1 do
+          begin
+            if (colourNum = length(sColor)) then
+              colourNum := 0;
+            aStyle := SeriesStyles.Add;
+            aStyle.Text := TableData.RowVariable.GetValueLabelFormatted(i, ValueLabelOutput);
+            aStyle.Brush.Color:=sColor[colourNum];
+            aStyle.Pen.Color := clSilver;
+            colourNum += 1;
+          end;
+        BarSeries.Legend.Multiplicity:=lmStyle;
+        BarSeries.Legend.GroupIndex  := 0;
+
+        Chart.Legend.Visible        := true;
+        Chart.Legend.UseSidebar     := true;
+        Chart.Legend.Frame.Visible  := false;
+        Chart.Legend.GroupTitles.Add(ByVarName);
+      end  // stratified
+    else
+      begin
+        aStyle := SeriesStyles.Add;
+        aStyle.Brush.Color := sColor[0];
+        aStyle.Pen.Color := clSilver;
+      end;
+      BarSeries.Styles := SeriesStyles;
+
+    // Add series to the chart
+    Chart.AddSeries(BarSeries);
+
+    if (yPct) then
+      yType := 'Percent'
+    else
+      yType := 'Count';
+    sTitle := yType + ' by ' + XVar.GetVariableLabel(VariableLabelOutput);
+    if (Varnames.Count > 1) then
+      sTitle += ' by ' + ByVarName;
+    if (WeightVarName <> '') then
+      sTitle += ' weighted (' + WeightVarName + ')';
+
+    VariableLabelOutput := VariableLabelTypeFromOptionList(cOptions, FExecutor.SetOptions, sovStatistics);
+    ChartConfiguration := FChartFactory.NewChartConfiguration();
+    ChartConfiguration.GetTitleConfiguration()
+      .SetTitle(sTitle)
+      .SetFootnote('')
+      .SetXAxisTitle(XVar.GetVariableLabel(VariableLabelOutput))
+      .SetYAxisTitle(yType);
+
+    ChartConfiguration.GetAxesConfiguration()
+      .GetXAxisConfiguration()
+      .SetShowAxisMarksAsDates(XVar.FieldType in DateFieldTypes);
+
+    with Chart do
+      begin
+        BottomAxis.Marks.Source := LabelSeries;
+        BottomAxis.Marks.Style  := smsLabel;
+        BottomAxis.Grid.Style   := psClear;
+        BottomAxis.Margin       := 0;
+        LeftAxis.Grid.Style     := psClear;
+        LeftAxis.Margin         := 0;
+        Frame.Visible           := false;
+      end;
+
+    Result.AddChart(Chart, ChartConfiguration);
+    VarNames.Free;
+    TablesAll.Free;
+    T.Free;
+  end; // create chart
   DataFile.Free;
   cOptions.Free;
   StratVariable.Free;

--- a/src/graph/commands/epicurve/epicurve.pas
+++ b/src/graph/commands/epicurve/epicurve.pas
@@ -104,121 +104,127 @@ begin
   // weight variable not allowed for epicurve
   WeightVarName := '';
 
-  DataFile := FExecutor.PrepareDatafile(VarNames, VarNames);
-  XVar := Datafile.Fields.FieldByName[VarNames[0]];
-  Chart := FChartFactory.NewChart();
-  HistogramData := THistogram.Create(FExecutor, Command);
-  if (cOptions.HasOption('interval', Opt)) then
-    HistogramData.Interval := Opt.Expr.AsInteger;
-  if (Varnames.Count = 1) then
-    begin
-      dummyVar := DataFile.NewField(ftInteger);
-      dummyVar.Name := dummyVarName;
-      Varnames.Add(dummyVarName);
-    end;
-  // Note: this does NOT call CalcTables with stratification
-  T := TTables.Create(FExecutor, FOutputCreator);
-  TablesAll  := T.CalcTables(Datafile, VarNames,
-                StratVariable, WeightVarName, cOptions, nilTablesRefMap);
-  TableData := TablesAll.UnstratifiedTable;
-  if (ReverseStrata) then
-    TableData.SortByRowLabel(true);
-  HistogramData.Fill(TableData);
-  HistogramData.HistogramToEpicurve;
-
-  ByVarName := Datafile.Fields.FieldByName[VarNames[1]].GetVariableLabel(VariableLabelOutput);
-
-  if (Varnames.IndexOf(dummyVarName) > -1) then
-    Varnames.Delete(Varnames.IndexOf(dummyVarName));
-
-  HistogramSource := THistogramSource.Create(Chart);
-  HistogramSource.Histogram := HistogramData;
-
-  BarSeries := TBarSeries.Create(Chart);
-  BarSeries.Source := HistogramSource;
-  BarSeries.Stacked := true;
-  BarSeries.BarWidthPercent := 100;
-  BarSeries.ShowInLegend := false;
-  SeriesStyles := TChartStyles.Create(Chart);
-
-  if (Varnames.Count > 1) then
-    begin
-      LegendSource := TListChartSource.Create(Chart);
-      LegendSeries := TBarSeries.Create(Chart);
-      LegendSeries.Source := LegendSource;
-      LegendStyles := TChartStyles.Create(Chart);
-      LegendSeries.ShowInLegend := true;
-      LegendSeries.Styles := LegendStyles;
-      LegendSeries.Legend.Multiplicity:=lmStyle;
-      LegendSeries.Legend.GroupIndex  := 0;
-      Chart.AddSeries(LegendSeries);
-
-      colourNum := 0;
-      box1 := 0;
-      for i := 0 to TableData.RowCount - 1 do
-        begin
-          // individual box styles
-          if (colourNum = length(sColor)) then
-            colourNum := 0;     // if more strata than colours, recycle the colours
-          for box := box1 to box1 + HistogramData.MaxCount[i] - 1 do
-            begin
-              aStyle := SeriesStyles.Add;
-              aStyle.Brush.Color:=sColor[colourNum];
-              aStyle.Pen.Color := clSilver;     // will work with any box colours
-            end;
-          LegendSource.Add(HistogramData.Base.ToDouble, 0);
-          aStyle := LegendStyles.Add;
-          aStyle.Text := TableData.RowVariable.GetValueLabelFormatted(i, ValueLabelOutput);
-          aStyle.Brush.Color:=sColor[colourNum];
-          colourNum += 1;
-          box1 += HistogramData.MaxCount[i];
-        end;
-
-      Chart.Legend.Visible        := true;
-      Chart.Legend.UseSidebar     := true;
-      Chart.Legend.Frame.Visible  := false;
-      Chart.Legend.GroupTitles.Add(ByVarName);
-    end
-  else
-    begin
-      aStyle := SeriesStyles.Add;
-      aStyle.Brush.Color := sColor[0];
-      aStyle.Pen.Color := clSilver;
-    end;
-  BarSeries.Styles := SeriesStyles;
-
-  Chart.AddSeries(BarSeries);
-
-   sTitle := 'Count by ' + XVar.GetVariableLabel(VariableLabelOutput);
-  if (Varnames.Count > 1) then
-    sTitle += ' by ' + ByVarName;
-  ChartConfiguration := FChartFactory.NewChartConfiguration();
-  ChartConfiguration.GetTitleConfiguration()
-    .SetTitle(sTitle)
-    .SetFootnote('')
-    .SetXAxisTitle(XVar.GetVariableLabel(VariableLabelOutput))
-    .SetYAxisTitle('Count');
-
-  ChartConfiguration.GetAxesConfiguration()
-    .GetXAxisConfiguration()
-    .SetShowAxisMarksAsDates(XVar.FieldType in DateFieldTypes);
-
-  with Chart do
-    begin
-      BottomAxis.Marks.Source := HistogramSource.AddAxisScales(Chart);
-      BottomAxis.Grid.Style   := psClear;
-      BottomAxis.Margin       := 0;
-      LeftAxis.Grid.Style     := psClear;
-      LeftAxis.Margin         := 0;
-      Frame.Visible           := false;
-    end;
-
+  // Create the command result
   Result := FChartFactory.NewGraphCommandResult();
-  Result.AddChart(Chart, ChartConfiguration);
-  XVar := nil;
-  VarNames.Free;
-  TablesAll.Free;
-  T.Free;
+  DataFile := FExecutor.PrepareDatafile(VarNames, VarNames);
+  if (DataFile.Size < 1) then
+    FExecutor.Error('No data')
+  else
+  begin
+    XVar := Datafile.Fields.FieldByName[VarNames[0]];
+    Chart := FChartFactory.NewChart();
+    HistogramData := THistogram.Create(FExecutor, Command);
+    if (cOptions.HasOption('interval', Opt)) then
+      HistogramData.Interval := Opt.Expr.AsInteger;
+    if (Varnames.Count = 1) then
+      begin
+        dummyVar := DataFile.NewField(ftInteger);
+        dummyVar.Name := dummyVarName;
+        Varnames.Add(dummyVarName);
+      end;
+    // Note: this does NOT call CalcTables with stratification
+    T := TTables.Create(FExecutor, FOutputCreator);
+    TablesAll  := T.CalcTables(Datafile, VarNames,
+                  StratVariable, WeightVarName, cOptions, nilTablesRefMap);
+    TableData := TablesAll.UnstratifiedTable;
+    if (ReverseStrata) then
+      TableData.SortByRowLabel(true);
+    HistogramData.Fill(TableData);
+    HistogramData.HistogramToEpicurve;
+
+    ByVarName := Datafile.Fields.FieldByName[VarNames[1]].GetVariableLabel(VariableLabelOutput);
+
+    if (Varnames.IndexOf(dummyVarName) > -1) then
+      Varnames.Delete(Varnames.IndexOf(dummyVarName));
+
+    HistogramSource := THistogramSource.Create(Chart);
+    HistogramSource.Histogram := HistogramData;
+
+    BarSeries := TBarSeries.Create(Chart);
+    BarSeries.Source := HistogramSource;
+    BarSeries.Stacked := true;
+    BarSeries.BarWidthPercent := 100;
+    BarSeries.ShowInLegend := false;
+    SeriesStyles := TChartStyles.Create(Chart);
+
+    if (Varnames.Count > 1) then
+      begin
+        LegendSource := TListChartSource.Create(Chart);
+        LegendSeries := TBarSeries.Create(Chart);
+        LegendSeries.Source := LegendSource;
+        LegendStyles := TChartStyles.Create(Chart);
+        LegendSeries.ShowInLegend := true;
+        LegendSeries.Styles := LegendStyles;
+        LegendSeries.Legend.Multiplicity:=lmStyle;
+        LegendSeries.Legend.GroupIndex  := 0;
+        Chart.AddSeries(LegendSeries);
+
+        colourNum := 0;
+        box1 := 0;
+        for i := 0 to TableData.RowCount - 1 do
+          begin
+            // individual box styles
+            if (colourNum = length(sColor)) then
+              colourNum := 0;     // if more strata than colours, recycle the colours
+            for box := box1 to box1 + HistogramData.MaxCount[i] - 1 do
+              begin
+                aStyle := SeriesStyles.Add;
+                aStyle.Brush.Color:=sColor[colourNum];
+                aStyle.Pen.Color := clSilver;     // will work with any box colours
+              end;
+            LegendSource.Add(HistogramData.Base.ToDouble, 0);
+            aStyle := LegendStyles.Add;
+            aStyle.Text := TableData.RowVariable.GetValueLabelFormatted(i, ValueLabelOutput);
+            aStyle.Brush.Color:=sColor[colourNum];
+            colourNum += 1;
+            box1 += HistogramData.MaxCount[i];
+          end;
+
+        Chart.Legend.Visible        := true;
+        Chart.Legend.UseSidebar     := true;
+        Chart.Legend.Frame.Visible  := false;
+        Chart.Legend.GroupTitles.Add(ByVarName);
+      end
+    else
+      begin
+        aStyle := SeriesStyles.Add;
+        aStyle.Brush.Color := sColor[0];
+        aStyle.Pen.Color := clSilver;
+      end;
+    BarSeries.Styles := SeriesStyles;
+
+    Chart.AddSeries(BarSeries);
+
+     sTitle := 'Count by ' + XVar.GetVariableLabel(VariableLabelOutput);
+    if (Varnames.Count > 1) then
+      sTitle += ' by ' + ByVarName;
+    ChartConfiguration := FChartFactory.NewChartConfiguration();
+    ChartConfiguration.GetTitleConfiguration()
+      .SetTitle(sTitle)
+      .SetFootnote('')
+      .SetXAxisTitle(XVar.GetVariableLabel(VariableLabelOutput))
+      .SetYAxisTitle('Count');
+
+    ChartConfiguration.GetAxesConfiguration()
+      .GetXAxisConfiguration()
+      .SetShowAxisMarksAsDates(XVar.FieldType in DateFieldTypes);
+
+    with Chart do
+      begin
+        BottomAxis.Marks.Source := HistogramSource.AddAxisScales(Chart);
+        BottomAxis.Grid.Style   := psClear;
+        BottomAxis.Margin       := 0;
+        LeftAxis.Grid.Style     := psClear;
+        LeftAxis.Margin         := 0;
+        Frame.Visible           := false;
+      end;
+
+    Result.AddChart(Chart, ChartConfiguration);
+    XVar := nil;
+    VarNames.Free;
+    TablesAll.Free;
+    T.Free;
+  end;
   DataFile.Free;
   StratVariable.Free;
   cOptions.Free;

--- a/src/graph/commands/histogram/histogram.pas
+++ b/src/graph/commands/histogram/histogram.pas
@@ -110,108 +110,114 @@ begin
 
   yPct := cOptions.HasOption('pct');
 
-  DataFile := FExecutor.PrepareDatafile(DFVars, DFVars);
-  XVar := Datafile.Fields.FieldByName[VarNames[0]];
-  Chart := FChartFactory.NewChart();
-  HistogramData := THistogram.Create(FExecutor, Command);
-  if (cOptions.HasOption('interval', Opt)) then
-    HistogramData.Interval := Opt.Expr.AsInteger;
-  HistogramData.PctCalc := yPct;
-  if (Varnames.Count = 1) then
-// add dummy variable to use Tables with one variable
-    begin
-      dummyVar := DataFile.NewField(ftInteger);
-      dummyVar.Name := dummyVarName;
-      Varnames.Add(dummyVarName);
-    end;
-// Note: this does NOT call CalcTables with stratification
-  T := TTables.Create(FExecutor, FOutputCreator);
-  TablesAll  := T.CalcTables(Datafile, VarNames,
-                StratVariable, WeightVarName, cOptions, nilTablesRefMap);
-  TableData := TablesAll.UnstratifiedTable;
-  if (ReverseStrata) then
-    TableData.SortByRowLabel(true);
-  HistogramData.Fill(TableData);
-
-  ByVarName := Datafile.Fields.FieldByName[VarNames[1]].GetVariableLabel(VariableLabelOutput);
-  // if dummy var was created, remove it now
-  if (Varnames.IndexOf(dummyVarName) > -1) then
-    Varnames.Delete(Varnames.IndexOf(dummyVarName));
-
-  HistogramSource := THistogramSource.Create(Chart);
-  HistogramSource.Histogram := HistogramData;
-  BarSeries := TBarSeries.Create(Chart);
-  BarSeries.Source := HistogramSource;
-  BarSeries.Stacked := cOptions.HasOption('stack');
-  BarSeries.BarWidthPercent := 100;
-  SeriesStyles := TChartStyles.Create(Chart);
-  if (Varnames.Count > 1) then
-    begin
-      colourNum := 0;
-      for i := 0 to TableData.RowCount - 1 do
-        begin
-          if (colourNum = length(sColor)) then
-            colourNum := 0;
-          aStyle := SeriesStyles.Add;
-          aStyle.Text := TableData.RowVariable.GetValueLabelFormatted(i, ValueLabelOutput);
-          aStyle.Brush.Color:=sColor[colourNum];
-          aStyle.Pen.Color := clSilver;
-          colourNum += 1;
-        end;
-      BarSeries.Legend.Multiplicity:=lmStyle;
-      BarSeries.Legend.GroupIndex  := 0;
-
-      Chart.Legend.Visible        := true;
-      Chart.Legend.UseSidebar     := true;
-      Chart.Legend.Frame.Visible  := false;
-      Chart.Legend.GroupTitles.Add(ByVarName);
-    end  // stratified
-  else
-    begin
-      aStyle := SeriesStyles.Add;
-      aStyle.Brush.Color := sColor[0];
-      aStyle.Pen.Color := clSilver;
-    end;
-    BarSeries.Styles := SeriesStyles;
-
-  Chart.AddSeries(BarSeries);
-
-  if (yPct) then
-    yType := 'Percent of Total'
-  else
-    yType := 'Count';
-  sTitle := yType + ' by ' + XVar.GetVariableLabel(VariableLabelOutput);
-  if (Varnames.Count > 1) then
-    sTitle += ' by ' + ByVarName;
-  if (WeightVarName <> '') then
-    sTitle += ' weighted (' + WeightVarName + ')';
-  ChartConfiguration := FChartFactory.NewChartConfiguration();
-  ChartConfiguration.GetTitleConfiguration()
-    .SetTitle(sTitle)
-    .SetFootnote('')
-    .SetXAxisTitle(XVar.GetVariableLabel(VariableLabelOutput))
-    .SetYAxisTitle(yType);
-
-  ChartConfiguration.GetAxesConfiguration()
-    .GetXAxisConfiguration()
-    .SetShowAxisMarksAsDates(XVar.FieldType in DateFieldTypes);
-
-  with Chart do
-    begin
-      BottomAxis.Marks.Source := HistogramSource.AddAxisScales(Chart);
-      BottomAxis.Grid.Style   := psClear;
-      BottomAxis.Margin       := 0;
-      LeftAxis.Grid.Style     := psClear;
-      LeftAxis.Margin         := 0;
-      Frame.Visible           := false;
-    end;
-
+  // Create the command result
   Result := FChartFactory.NewGraphCommandResult();
-  Result.AddChart(Chart, ChartConfiguration);
-  XVar := nil;
-  VarNames.Free;
-  TablesAll.Free;
-  T.Free;
+  DataFile := FExecutor.PrepareDatafile(DFVars, DFVars);
+  if (DataFile.Size < 1) then
+    FExecutor.Error('No data')
+  else
+  begin
+    XVar := Datafile.Fields.FieldByName[VarNames[0]];
+    Chart := FChartFactory.NewChart();
+    HistogramData := THistogram.Create(FExecutor, Command);
+    if (cOptions.HasOption('interval', Opt)) then
+      HistogramData.Interval := Opt.Expr.AsInteger;
+    HistogramData.PctCalc := yPct;
+    if (Varnames.Count = 1) then
+  // add dummy variable to use Tables with one variable
+      begin
+        dummyVar := DataFile.NewField(ftInteger);
+        dummyVar.Name := dummyVarName;
+        Varnames.Add(dummyVarName);
+      end;
+  // Note: this does NOT call CalcTables with stratification
+    T := TTables.Create(FExecutor, FOutputCreator);
+    TablesAll  := T.CalcTables(Datafile, VarNames,
+                  StratVariable, WeightVarName, cOptions, nilTablesRefMap);
+    TableData := TablesAll.UnstratifiedTable;
+    if (ReverseStrata) then
+      TableData.SortByRowLabel(true);
+    HistogramData.Fill(TableData);
+
+    ByVarName := Datafile.Fields.FieldByName[VarNames[1]].GetVariableLabel(VariableLabelOutput);
+    // if dummy var was created, remove it now
+    if (Varnames.IndexOf(dummyVarName) > -1) then
+      Varnames.Delete(Varnames.IndexOf(dummyVarName));
+
+    HistogramSource := THistogramSource.Create(Chart);
+    HistogramSource.Histogram := HistogramData;
+    BarSeries := TBarSeries.Create(Chart);
+    BarSeries.Source := HistogramSource;
+    BarSeries.Stacked := cOptions.HasOption('stack');
+    BarSeries.BarWidthPercent := 100;
+    SeriesStyles := TChartStyles.Create(Chart);
+    if (Varnames.Count > 1) then
+      begin
+        colourNum := 0;
+        for i := 0 to TableData.RowCount - 1 do
+          begin
+            if (colourNum = length(sColor)) then
+              colourNum := 0;
+            aStyle := SeriesStyles.Add;
+            aStyle.Text := TableData.RowVariable.GetValueLabelFormatted(i, ValueLabelOutput);
+            aStyle.Brush.Color:=sColor[colourNum];
+            aStyle.Pen.Color := clSilver;
+            colourNum += 1;
+          end;
+        BarSeries.Legend.Multiplicity:=lmStyle;
+        BarSeries.Legend.GroupIndex  := 0;
+
+        Chart.Legend.Visible        := true;
+        Chart.Legend.UseSidebar     := true;
+        Chart.Legend.Frame.Visible  := false;
+        Chart.Legend.GroupTitles.Add(ByVarName);
+      end  // stratified
+    else
+      begin
+        aStyle := SeriesStyles.Add;
+        aStyle.Brush.Color := sColor[0];
+        aStyle.Pen.Color := clSilver;
+      end;
+      BarSeries.Styles := SeriesStyles;
+
+    Chart.AddSeries(BarSeries);
+
+    if (yPct) then
+      yType := 'Percent of Total'
+    else
+      yType := 'Count';
+    sTitle := yType + ' by ' + XVar.GetVariableLabel(VariableLabelOutput);
+    if (Varnames.Count > 1) then
+      sTitle += ' by ' + ByVarName;
+    if (WeightVarName <> '') then
+      sTitle += ' weighted (' + WeightVarName + ')';
+    ChartConfiguration := FChartFactory.NewChartConfiguration();
+    ChartConfiguration.GetTitleConfiguration()
+      .SetTitle(sTitle)
+      .SetFootnote('')
+      .SetXAxisTitle(XVar.GetVariableLabel(VariableLabelOutput))
+      .SetYAxisTitle(yType);
+
+    ChartConfiguration.GetAxesConfiguration()
+      .GetXAxisConfiguration()
+      .SetShowAxisMarksAsDates(XVar.FieldType in DateFieldTypes);
+
+    with Chart do
+      begin
+        BottomAxis.Marks.Source := HistogramSource.AddAxisScales(Chart);
+        BottomAxis.Grid.Style   := psClear;
+        BottomAxis.Margin       := 0;
+        LeftAxis.Grid.Style     := psClear;
+        LeftAxis.Margin         := 0;
+        Frame.Visible           := false;
+      end;
+
+    Result.AddChart(Chart, ChartConfiguration);
+    XVar := nil;
+    VarNames.Free;
+    TablesAll.Free;
+    T.Free;
+  end;
   DataFile.Free;
   StratVariable.Free;
   cOptions.Free;

--- a/src/graph/commands/scatter/scatter.pas
+++ b/src/graph/commands/scatter/scatter.pas
@@ -60,72 +60,75 @@ begin
   end;
   // Get Variable names
   VarNames := Command.VariableList.GetIdentsAsList;
+  // Create the command result
+  Result := FChartFactory.NewGraphCommandResult();
 
   // Get the data and fields.
   DataFile := FExecutor.PrepareDatafile(VarNames, VarNames);
-  XVar := Datafile.Fields.FieldByName[VarNames[0]];
-  YVar := Datafile.Fields.FieldByName[Varnames[1]];
-  DataFile.SortRecords(XVar);
-  Varnames.Free;
+  if (DataFile.Size < 1) then
+    FExecutor.Error('No data')
+  else
+  begin
+    Chart := FChartFactory.NewChart();
+    XVar := Datafile.Fields.FieldByName[VarNames[0]];
+    YVar := Datafile.Fields.FieldByName[Varnames[1]];
+    DataFile.SortRecords(XVar);
+    Varnames.Free;
 
-  // Create the charts
-  Chart := FChartFactory.NewChart();
+    // Create our own datasource
+    // - datasource is destroyed by the chart, so we let it handle the datafile destruction
+    //   otherwise we would leak memory.
+    ScatterSource := TScatterSource.Create(Chart);
+    ScatterSource.Datafile := DataFile;
+    ScatterSource.XVariableName := XVar.Name;
+    ScatterSource.YVariableName := YVar.Name;
+    ScatterSource.Sorted := true;
 
-  // Create our own datasource
-  // - datasource is destroyed by the chart, so we let it handle the datafile destruction
-  //   otherwise we would leak memory.
-  ScatterSource := TScatterSource.Create(Chart);
-  ScatterSource.Datafile := DataFile;
-  ScatterSource.XVariableName := XVar.Name;
-  ScatterSource.YVariableName := YVar.Name;
-  ScatterSource.Sorted := true;
+    // Get options
 
-  // Get options
+    sLine := Command.HasOption('l');
+    sPoints := (not Command.HasOption('l')) or Command.HasOption('p');
 
-  sLine := Command.HasOption('l');
-  sPoints := (not Command.HasOption('l')) or Command.HasOption('p');
-
-  // Create the line/point series
-  LineSeries := TLineSeries.Create(Chart);
-  with LineSeries do
-    begin
-      Source := ScatterSource;
-      ShowPoints := sPoints;
-      if (sPoints) then
+    // Create the line/point series
+    LineSeries := TLineSeries.Create(Chart);
+    with LineSeries do
       begin
-        Pointer.Pen.Color := sColor[0];
-        Pointer.Style := psCircle;
-        Linetype := ltNone;
+        Source := ScatterSource;
+        ShowPoints := sPoints;
+        if (sPoints) then
+        begin
+          Pointer.Pen.Color := sColor[0];
+          Pointer.Style := psCircle;
+          Linetype := ltNone;
+        end;
+        if (Sline) then
+        begin
+          LineType := ltFromPrevious;
+          LinePen.Color:= sColor[0];
+        end;
       end;
-      if (Sline) then
-      begin
-        LineType := ltFromPrevious;
-        LinePen.Color:= sColor[0];
-      end;
-    end;
-  // Add series to the chart
-  Chart.AddSeries(LineSeries);
+    // Add series to the chart
+    Chart.AddSeries(LineSeries);
 
-  // Create the titles
-  VariableLabelType := VariableLabelTypeFromOptionList(Command.Options, FExecutor.SetOptions, sovStatistics);
-  ChartConfiguration := FChartFactory.NewChartConfiguration();
-  ChartConfiguration.GetTitleConfiguration()
-    .SetTitle(XVar.GetVariableLabel(VariableLabelType) + ' vs. ' + YVar.GetVariableLabel(VariableLabelType))
-    .SetFootnote('')
-    .SetXAxisTitle(XVar.GetVariableLabel(VariableLabelType))
-    .SetYAxisTitle(YVar.GetVariableLabel(VariableLabelType));
+    // Create the titles
+    VariableLabelType := VariableLabelTypeFromOptionList(Command.Options, FExecutor.SetOptions, sovStatistics);
+    ChartConfiguration := FChartFactory.NewChartConfiguration();
+    ChartConfiguration.GetTitleConfiguration()
+      .SetTitle(XVar.GetVariableLabel(VariableLabelType) + ' vs. ' + YVar.GetVariableLabel(VariableLabelType))
+      .SetFootnote('')
+      .SetXAxisTitle(XVar.GetVariableLabel(VariableLabelType))
+      .SetYAxisTitle(YVar.GetVariableLabel(VariableLabelType));
 
-  ChartConfiguration.GetAxesConfiguration()
-    .GetXAxisConfiguration()
-    .SetShowAxisMarksAsDates(XVar.FieldType in DateFieldTypes);
+    ChartConfiguration.GetAxesConfiguration()
+      .GetXAxisConfiguration()
+      .SetShowAxisMarksAsDates(XVar.FieldType in DateFieldTypes);
 
-  ChartConfiguration.GetAxesConfiguration()
-    .GetYAxisConfiguration()
-    .SetShowAxisMarksAsDates(YVar.FieldType in DateFieldTypes);
+    ChartConfiguration.GetAxesConfiguration()
+      .GetYAxisConfiguration()
+      .SetShowAxisMarksAsDates(YVar.FieldType in DateFieldTypes);
 
-  // Create the command result
-  Result := FChartFactory.NewGraphCommandResult();
-  Result.AddChart(Chart, ChartConfiguration);
+    Result.AddChart(Chart, ChartConfiguration);
+  end;
 end;
 
 initialization

--- a/src/graph/graphform/savegraphdialogaction.pas
+++ b/src/graph/graphform/savegraphdialogaction.pas
@@ -14,7 +14,6 @@ type
   TSaveGraphDialogAction = class(TCustomSaveGraphAction)
   private
     FSaveDialog: TSaveDialog;
-    procedure FilterChange(Sender: TObject);
   protected
     procedure UpdateReadyState(); override;
     procedure SaveGraphExecute(Sender: TObject); override;
@@ -30,16 +29,6 @@ uses
 
 { TSaveGraphDialogAction }
 
-procedure TSaveGraphDialogAction.FilterChange(Sender: TObject);
-begin
-  case FSaveDialog.FilterIndex of
-    1: GraphExportType := etSVG;
-    2: GraphExportType := etPNG;
-    3: GraphExportType := etJPG;
-  end;
-  FSaveDialog.DefaultExt := ExportExt[GraphExportType];
-end;
-
 procedure TSaveGraphDialogAction.UpdateReadyState();
 begin
   Enabled := Assigned(Chart);
@@ -49,23 +38,27 @@ procedure TSaveGraphDialogAction.SaveGraphExecute(Sender: TObject);
 begin
   if (not FSaveDialog.Execute) then
     Exit;
-
   Filename := FSaveDialog.FileName;
-
+  if (not ExtensionOK) then
+  begin
+    ShowMessage('"' + Filename + '"' + LineEnding +
+      'does not have a valid file extension.' + LineEnding +
+      '(jpg, jpeg, png, svg)' + LineEnding + LineEnding +
+      'Nothing saved.');
+    exit;
+  end;
   inherited SaveGraphExecute(Sender);
+  FSaveDialog.FileName := '';
 end;
 
 constructor TSaveGraphDialogAction.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
-
   FSaveDialog := TSaveDialog.Create(Self);
-  FSaveDialog.Filter := ' |*.*|SVG File|*.svg|PNG File|*.png|JPEG File|*.jpg;*.jpeg';
-  FSaveDialog.FilterIndex := 0;
-  FSaveDialog.OnTypeChange := @FilterChange;
+  FSaveDialog.Filter := '';
   FSaveDialog.InitialDir := GetCurrentDirUTF8;
   FSaveDialog.Options := [ofOverwritePrompt, ofPathMustExist, ofEnableSizing];
-  FSaveDialog.Title := 'Add file extension or choose a format below';
+  FSaveDialog.Title := 'File name MUST have a valid type: .jpg, .png or .svg';
 end;
 
 end.

--- a/src/graph/savegraphaction.pas
+++ b/src/graph/savegraphaction.pas
@@ -12,7 +12,6 @@ type
   { TSaveGraphAction }
 
   TGraphExportType = (
-    etNone,
     etSVG,
     etPNG,
     etJPG
@@ -20,7 +19,6 @@ type
 
 const
   ExportExt: array[TGraphExportType] of string = (
-    '*',
     '.svg',
     '.png',
     '.jpg'
@@ -36,6 +34,7 @@ type
   private
     FChart: TChart;
     FFilename: UTF8String;
+    FExtensionOK: Boolean;
     FGraphExportType: TGraphExportType;
     FGraphSize: TSize;
     procedure SaveToRaster(ImageClass: TRasterImageClass; Filename: UTF8String);
@@ -49,6 +48,7 @@ type
     property GraphExportType: TGraphExportType read FGraphExportType write FGraphExportType;
     property GraphSize: TSize read FGraphSize write FGraphSize;
     property Filename: UTF8String read FFilename write SetFilename;
+    property ExtensionOK: Boolean read FExtensionOK write FExtensionOK;
   public
     constructor Create(AOwner: TComponent); override;
   end;
@@ -96,17 +96,13 @@ end;
 
 procedure TCustomSaveGraphAction.UpdateExportType();
 var
-  Ext: UTF8String;
+  ext: UTF8String;
 begin
   if (FFilename = '') then
     Exit;
-
-  if (FGraphExportType <> etNone) then
-    Exit;
-
-
-  Ext := ExtractFileExt(FFilename);
-  case Ext of
+  ext := ExtractFileExt(FFilename);
+  FExtensionOK := true;
+  case ext of
     '.svg':
       FGraphExportType := etSVG;
     '.png':
@@ -114,8 +110,8 @@ begin
     '.jpg',
     '.jpeg':
       FGraphExportType := etJPG;
-  else
-    raise EIncorrectGraphExtension.Create('"' + ext + '" is not a supported filetype!');
+    else
+      FExtensionOK := false;
   end;
 end;
 
@@ -141,10 +137,7 @@ end;
 constructor TCustomSaveGraphAction.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
-
-  FGraphExportType := etNone;
   FGraphSize := TSize.Create(1024, 768);
-
   OnExecute := @SaveGraphExecute;
   Caption := 'Save as ...';
 end;


### PR DESCRIPTION
# Two things done # 
## 1. Change to graph SaveAs dialog. ##
* The use of a file filter is problematic, since the extension is not applied when the dialog checks for an existing file.
* The exception in code for illegal extension is not useful
### Changes ###
* extension drop-down eliminated; user must specify the extension
* simple message if extension is not legal
## 2. No graph if no data ##
* Need to check for no data before calling CalcTables (barchart, histogram, epicurve)
* Must create graph command result before this check since graph factory expects a result, even if empty
### Changes ###
* create graph command result before data check
* check for empty data and bypass chart creation if no data
