### PR TITLE
Implement set Output Font Name effective with set "Output Format" := "html"

### DIFF
--- a/epidataanalysis.lpi
+++ b/epidataanalysis.lpi
@@ -9,12 +9,8 @@
       <SessionStorage Value="InProjectDir"/>
       <AutoCreateForms Value="False"/>
       <Title Value="Analysis"/>
-      <Scaled Value="True"/>
       <ResourceType Value="res"/>
       <UseXPManifest Value="True"/>
-      <XPManifest>
-        <DpiAware Value="True"/>
-      </XPManifest>
       <Icon Value="0"/>
     </General>
     <VersionInfo>

--- a/epidataanalysis.lpi
+++ b/epidataanalysis.lpi
@@ -9,8 +9,12 @@
       <SessionStorage Value="InProjectDir"/>
       <AutoCreateForms Value="False"/>
       <Title Value="Analysis"/>
+      <Scaled Value="True"/>
       <ResourceType Value="res"/>
       <UseXPManifest Value="True"/>
+      <XPManifest>
+        <DpiAware Value="True"/>
+      </XPManifest>
       <Icon Value="0"/>
     </General>
     <VersionInfo>
@@ -291,7 +295,7 @@
         <PackageName Value="LCL"/>
       </Item13>
     </RequiredPackages>
-    <Units Count="196">
+    <Units Count="197">
       <Unit0>
         <Filename Value="epidataanalysis.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -1113,6 +1117,10 @@
         <Filename Value="src/dialogs/stat_dialogs/pareto/pareto_main_view.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit195>
+      <Unit196>
+        <Filename Value="src/output/cocoawebviewer.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit196>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/epidataanalysis.lpr
+++ b/epidataanalysis.lpr
@@ -40,7 +40,6 @@ end;
 
 
 begin
-  Application.Scaled:=True;
   Application.Title:='Analysis';
   OnGetApplicationName := @EpiDataApplicationName;
   OnGetVendorName := @EpiDataVendorName;

--- a/epidataanalysis.lpr
+++ b/epidataanalysis.lpr
@@ -40,7 +40,8 @@ end;
 
 
 begin
-  Application.Title := 'Analysis';
+  Application.Scaled:=True;
+  Application.Title:='Analysis';
   OnGetApplicationName := @EpiDataApplicationName;
   OnGetVendorName := @EpiDataVendorName;
 

--- a/epidataanalysis.lpr
+++ b/epidataanalysis.lpr
@@ -40,7 +40,7 @@ end;
 
 
 begin
-  Application.Title:='Analysis';
+  Application.Title := 'Analysis';
   OnGetApplicationName := @EpiDataApplicationName;
   OnGetVendorName := @EpiDataVendorName;
 

--- a/src/main.lfm
+++ b/src/main.lfm
@@ -43,19 +43,19 @@ object MainForm: TMainForm
       Top = 13
       Width = 75
       Caption = 'test'
+      OnClick = Button2Click
       ParentFont = False
       TabOrder = 0
-      OnClick = Button2Click
     end
     object Button3: TButton
       Left = 112
       Height = 25
       Top = 13
       Width = 75
+      OnClick = Button3Click
       Caption = 'SaveHtml'
       ParentFont = False
       TabOrder = 1
-      OnClick = Button3Click
     end
     object Label1: TLabel
       Left = 307
@@ -146,14 +146,14 @@ object MainForm: TMainForm
       Align = alBottom
       ItemHeight = 0
       MultiSelect = True
+      OnDblClick = HistoryListBoxDblClick
+      OnDrawItem = HistoryListBoxDrawItem
+      OnKeyDown = HistoryListBoxKeyDown
       ParentFont = False
       PopupMenu = HistoryPopupMenu
       Style = lbOwnerDrawFixed
       TabOrder = 2
       Visible = False
-      OnDblClick = HistoryListBoxDblClick
-      OnDrawItem = HistoryListBoxDrawItem
-      OnKeyDown = HistoryListBoxKeyDown
     end
   end
   object RightSideSplitter: TSplitter

--- a/src/main.lfm
+++ b/src/main.lfm
@@ -14,7 +14,7 @@ object MainForm: TMainForm
   OnDropFiles = FormDropFiles
   OnShow = FormShow
   Position = poDefault
-  LCLVersion = '2.0.11.0'
+  LCLVersion = '3.2.0.0'
   object PageControl1: TPageControl
     Left = 245
     Height = 613
@@ -43,9 +43,9 @@ object MainForm: TMainForm
       Top = 13
       Width = 75
       Caption = 'test'
-      OnClick = Button2Click
       ParentFont = False
       TabOrder = 0
+      OnClick = Button2Click
     end
     object Button3: TButton
       Left = 112
@@ -53,9 +53,9 @@ object MainForm: TMainForm
       Top = 13
       Width = 75
       Caption = 'SaveHtml'
-      OnClick = Button3Click
       ParentFont = False
       TabOrder = 1
+      OnClick = Button3Click
     end
     object Label1: TLabel
       Left = 307
@@ -146,14 +146,14 @@ object MainForm: TMainForm
       Align = alBottom
       ItemHeight = 0
       MultiSelect = True
-      OnDblClick = HistoryListBoxDblClick
-      OnDrawItem = HistoryListBoxDrawItem
-      OnKeyDown = HistoryListBoxKeyDown
       ParentFont = False
       PopupMenu = HistoryPopupMenu
       Style = lbOwnerDrawFixed
       TabOrder = 2
       Visible = False
+      OnDblClick = HistoryListBoxDblClick
+      OnDrawItem = HistoryListBoxDrawItem
+      OnKeyDown = HistoryListBoxKeyDown
     end
   end
   object RightSideSplitter: TSplitter

--- a/src/main.pas
+++ b/src/main.pas
@@ -1540,9 +1540,8 @@ procedure TMainForm.OutputFontChange(Sender: TObject);
 begin
   FOutputViewer.UpdateFontAndSize(Executor);
   // put cursor back into command line;
-    CmdEditFocusActionExecute(nil);
-//    EnableAutoSizing;
-    RedrawOutput;
+  CmdEditFocusActionExecute(nil);
+  RedrawOutput;
 end;
 
 procedure TMainForm.OutputViewerChanges(Sender: TObject);

--- a/src/main.pas
+++ b/src/main.pas
@@ -1539,6 +1539,10 @@ end;
 procedure TMainForm.OutputFontChange(Sender: TObject);
 begin
   FOutputViewer.UpdateFontAndSize(Executor);
+  // put cursor back into command line;
+    CmdEditFocusActionExecute(nil);
+//    EnableAutoSizing;
+    RedrawOutput;
 end;
 
 procedure TMainForm.OutputViewerChanges(Sender: TObject);
@@ -1602,7 +1606,6 @@ begin
   FOutputViewer.UpdateFontAndSize(Executor);
   FOutputViewer.GetContextMenu.OnSaveOutputClick := @SaveOutputActionExecute;
 // put cursor back into command line;
-// for some reason, this doesn't happen after automatically this command
   CmdEditFocusActionExecute(nil);
   EnableAutoSizing;
   RedrawOutput;

--- a/src/output/cocoawebviewer.pas
+++ b/src/output/cocoawebviewer.pas
@@ -36,7 +36,7 @@ end;
 implementation
 
 uses
-  Controls, Graphics, outputgenerator_html, Clipbrd, LCLType, LMessages;
+  Controls, Graphics, outputgenerator_html, Clipbrd, LCLType, LMessages, regexpr, ana_globals;
 
 { TCocoaWebSheet }
 
@@ -77,8 +77,28 @@ begin
 end;
 
 procedure TCocoaWebSheet.UpdateFontAndSize(AExecutor: TExecutor);
+var
+  regex: TRegExpr;
+  // match font name already added to HTML_OUTPUT_CSS
+  regexPattern: string = '(\.body\s*\{font-family\:\s*")(.{1,30})(")';
 begin
-  //
+  // Add output font name to standard CSS
+  regex := TRegExpr.Create;
+  try
+     regex.ModifierI := True;
+     regex.Expression := regexPattern;
+     if (regex.Exec(HTML_OUTPUT_CSS)) then
+       HTML_OUTPUT_CSS := ReplaceRegExpr(regexPattern, HTML_OUTPUT_CSS,
+                         '$1' + AExecutor.GetSetOptionValue(ANA_SO_OUTPUT_FONT_NAME) +
+                         '$3', true)
+     else
+       HTML_OUTPUT_CSS := StringReplace(HTML_OUTPUT_CSS, '.body {',
+                         '.body {font-family: "' +
+                          AExecutor.GetSetOptionValue(ANA_SO_OUTPUT_FONT_NAME) +
+                         '"; ', []);
+  finally
+     regex.Destroy;
+  end;
 end;
 
 function TCocoaWebSheet.GetLineAtCaret: String;

--- a/src/output/htmlviewer.pas
+++ b/src/output/htmlviewer.pas
@@ -56,7 +56,7 @@ function IsHTMLSupported: boolean;
 
 Implementation
 
-Uses Main, cef3ref, cef3scp, outputgenerator_html;
+Uses Main, cef3ref, cef3scp, outputgenerator_html, regexpr, ana_globals;
 
 var
   fHtmlSupported: boolean;
@@ -203,8 +203,27 @@ begin
 end;
 
 procedure TWebPanel.UpdateFontAndSize(AExecutor: TExecutor);
+var
+  regex: TRegExpr;
+  regexPattern: string = '(\.body\s*\{font-family\:\s*")(.{1,30})(")';
 begin
-  //
+  // Add output font name to standard CSS
+  regex := TRegExpr.Create;
+  try
+     regex.ModifierI := True;
+     regex.Expression := regexPattern;
+     if (regex.Exec(HTML_OUTPUT_CSS)) then
+       HTML_OUTPUT_CSS := ReplaceRegExpr(regexPattern, HTML_OUTPUT_CSS,
+                         '$1' + AExecutor.GetSetOptionValue(ANA_SO_OUTPUT_FONT_NAME) +
+                         '$3', true)
+     else
+       HTML_OUTPUT_CSS := StringReplace(HTML_OUTPUT_CSS, '.body {',
+                         '.body {font-family: "' +
+                          AExecutor.GetSetOptionValue(ANA_SO_OUTPUT_FONT_NAME) +
+                         '"; ', []);
+  finally
+     regex.Destroy;
+  end;
 end;
 
 var

--- a/src/output/oldhtmlviewer.pas
+++ b/src/output/oldhtmlviewer.pas
@@ -32,7 +32,7 @@ type
 implementation
 
 uses
-  Controls, Graphics, outputgenerator_html, Clipbrd;
+  Controls, Graphics, outputgenerator_html, Clipbrd, regexpr, ana_globals;
 
 { TOldHtmlSheet }
 
@@ -78,8 +78,27 @@ begin
 end;
 
 procedure TOldHtmlSheet.UpdateFontAndSize(AExecutor: TExecutor);
+var
+  regex: TRegExpr;
+  regexPattern: string = '(\.body\s*\{font-family\:\s*")(.{1,30})(")';
 begin
-  //
+  // Add output font name to standard CSS
+  regex := TRegExpr.Create;
+  try
+     regex.ModifierI := True;
+     regex.Expression := regexPattern;
+     if (regex.Exec(HTML_OUTPUT_CSS)) then
+       HTML_OUTPUT_CSS := ReplaceRegExpr(regexPattern, HTML_OUTPUT_CSS,
+                         '$1' + AExecutor.GetSetOptionValue(ANA_SO_OUTPUT_FONT_NAME) +
+                         '$3', true)
+     else
+       HTML_OUTPUT_CSS := StringReplace(HTML_OUTPUT_CSS, '.body {',
+                         '.body {font-family: "' +
+                          AExecutor.GetSetOptionValue(ANA_SO_OUTPUT_FONT_NAME) +
+                         '"; ', []);
+  finally
+     regex.Destroy;
+  end;
 end;
 
 function TOldHtmlSheet.GetLineAtCaret: String;

--- a/src/output/outputgenerator_html.pas
+++ b/src/output/outputgenerator_html.pas
@@ -33,7 +33,7 @@ type
   end;
 
 const
-  HTML_OUTPUT_CSS =
+  HTML_OUTPUT_CSS: UTF8String =
         '<STYLE type="text/css">' + LineEnding +
         '<!--' + LineEnding +
         '/* EpiData Reporting Minimalistic style sheet - white background' + LineEnding +


### PR DESCRIPTION
fonts have never shown properly with set "output format" := "html"

The three web viewers (oldhtmlviewer, htmlviewer, cocoahtmlviewer) are now aware of fonts and can implement changes made with the set command.

The most important change was to make the standard CSS a typed constant, which can be changed in the code. 

NOTE: this PR does not include changes to DPI awareness. That probably needs to done as well.