### PR TITLE
Revert axis transformation destruction

### DIFF
--- a/src/graph/chartcommand/chartpair.pas
+++ b/src/graph/chartcommand/chartpair.pas
@@ -52,10 +52,6 @@ destructor TChartPair.Destroy;
 var
   i: integer;
 begin
-  // must clear any axis transformations before destroying chart
-  for i := 0 to Chart.AxisList.Count - 1 do
-    if (Assigned(Chart.AxisList.Axes[i].Transformations)) then
-      Chart.AxisList.Axes[i].Transformations := nil;
   Chart := nil;
   Configuration := nil;
   inherited Destroy;


### PR DESCRIPTION
Cannot destroy axis transformations in TChartPair.Destroy, because the chart has not yet been made. Destroying them here causes the chart (pareto) to have the same left and right axis scales.

Where are the actual charts destroyed? Any why don't they take care of axis transformations?