### PR TITLE
Jamie/add stratum value to charttitles

### DIFF
--- a/src/graph/chartcommand/chartpair.pas
+++ b/src/graph/chartcommand/chartpair.pas
@@ -49,8 +49,6 @@ begin
 end;
 
 destructor TChartPair.Destroy;
-var
-  i: integer;
 begin
   Chart := nil;
   Configuration := nil;

--- a/src/graph/charttitles/charttitles.impl.pas
+++ b/src/graph/charttitles/charttitles.impl.pas
@@ -18,17 +18,21 @@ type
     FXAxisTitle: UTF8String;
     FYAxisTitle: UTF8String;
     FY2AxisTitle: UTF8String;
+    FStratumValue: UTF8String;
   public
+    constructor Create;
     function GetTitle(): UTF8String;
     function GetFootnote(): UTF8String;
     function GetXAxisTitle(): UTF8String;
     function GetYAxisTitle(): UTF8String;
     function GetY2AxisTitle(): UTF8String;
+    function GetStratumValue(): UTF8String;
     function SetTitle(Text: UTF8String): IChartTitleConfiguration;
     function SetFootnote(Text: UTF8String): IChartTitleConfiguration;
     function SetXAxisTitle(Text: UTF8String): IChartTitleConfiguration;
     function SetYAxisTitle(Text: UTF8String): IChartTitleConfiguration;
     function SetY2AxisTitle(Text: UTF8String): IChartTitleConfiguration;
+    function SetStratumValue(Value: UTF8String): IChartTitleConfiguration;
   end;
 
 implementation
@@ -61,6 +65,11 @@ begin
   Result := FY2AxisTitle;
 end;
 
+function TChartTitlesConfiguration.GetStratumValue(): UTF8String;
+begin
+    Result := FStratumValue
+end;
+
 function TChartTitlesConfiguration.SetTitle(Text: UTF8String): IChartTitleConfiguration;
 begin
   FTitle := Text;
@@ -89,6 +98,17 @@ function TChartTitlesConfiguration.SetY2AxisTitle(Text: UTF8String): IChartTitle
 begin
   FY2AxisTitle := Text;
   Result := Self;
+end;
+
+function TChartTitlesConfiguration.SetStratumValue(Value: UTF8String): IChartTitleConfiguration;
+begin
+  FStratumValue := Value;
+  Result := Self;
+end;
+
+constructor TChartTitlesConfiguration.Create;
+begin
+  FStratumValue := '';
 end;
 
 end.

--- a/src/graph/charttitles/charttitles.pas
+++ b/src/graph/charttitles/charttitles.pas
@@ -14,6 +14,7 @@ type
     function GetXAxisTitle(): UTF8String;
     function GetYAxisTitle(): UTF8String;
     function GetY2AxisTitle(): UTF8String;
+    function GetStratumValue(): UTF8String;
   end;
 
   IChartTitleConfiguration = interface(IChartTitles)['{4DCBD46E-C9EB-46A4-9313-7B3C943F7B82}']
@@ -22,6 +23,7 @@ type
     function SetXAxisTitle(Text: UTF8String): IChartTitleConfiguration;
     function SetYAxisTitle(Text: UTF8String): IChartTitleConfiguration;
     function SetY2AxisTitle(Text: UTF8String): IChartTitleConfiguration;
+    function SetStratumValue(Text: UTF8String): IChartTitleConfiguration;
   end;
 
 implementation


### PR DESCRIPTION
The idea here is that the names for multiple files saved from a command that produces multiple charts (only pareto for now) will have to be unique. The user can specify

!e:="cmd.jpg"

and analysis will save files for strata with values "A" and "B" as

cmd-A.jpg and cmd-B.jpg

I've also cleaned up code in chartpair.pas