### PR TITLE
Jamie/save multiple charts from one command

### DIFF
--- a/src/graph/chartcommand/chartpair.pas
+++ b/src/graph/chartcommand/chartpair.pas
@@ -49,8 +49,6 @@ begin
 end;
 
 destructor TChartPair.Destroy;
-var
-  i: integer;
 begin
   Chart := nil;
   Configuration := nil;

--- a/src/graph/charttitles/charttitles.impl.pas
+++ b/src/graph/charttitles/charttitles.impl.pas
@@ -18,17 +18,21 @@ type
     FXAxisTitle: UTF8String;
     FYAxisTitle: UTF8String;
     FY2AxisTitle: UTF8String;
+    FStratumValue: UTF8String;
   public
+    constructor Create;
     function GetTitle(): UTF8String;
     function GetFootnote(): UTF8String;
     function GetXAxisTitle(): UTF8String;
     function GetYAxisTitle(): UTF8String;
     function GetY2AxisTitle(): UTF8String;
+    function GetStratumValue(): UTF8String;
     function SetTitle(Text: UTF8String): IChartTitleConfiguration;
     function SetFootnote(Text: UTF8String): IChartTitleConfiguration;
     function SetXAxisTitle(Text: UTF8String): IChartTitleConfiguration;
     function SetYAxisTitle(Text: UTF8String): IChartTitleConfiguration;
     function SetY2AxisTitle(Text: UTF8String): IChartTitleConfiguration;
+    function SetStratumValue(Value: UTF8String): IChartTitleConfiguration;
   end;
 
 implementation
@@ -61,6 +65,11 @@ begin
   Result := FY2AxisTitle;
 end;
 
+function TChartTitlesConfiguration.GetStratumValue(): UTF8String;
+begin
+    Result := FStratumValue
+end;
+
 function TChartTitlesConfiguration.SetTitle(Text: UTF8String): IChartTitleConfiguration;
 begin
   FTitle := Text;
@@ -89,6 +98,17 @@ function TChartTitlesConfiguration.SetY2AxisTitle(Text: UTF8String): IChartTitle
 begin
   FY2AxisTitle := Text;
   Result := Self;
+end;
+
+function TChartTitlesConfiguration.SetStratumValue(Value: UTF8String): IChartTitleConfiguration;
+begin
+  FStratumValue := Value;
+  Result := Self;
+end;
+
+constructor TChartTitlesConfiguration.Create;
+begin
+  FStratumValue := '';
 end;
 
 end.

--- a/src/graph/charttitles/charttitles.pas
+++ b/src/graph/charttitles/charttitles.pas
@@ -14,6 +14,7 @@ type
     function GetXAxisTitle(): UTF8String;
     function GetYAxisTitle(): UTF8String;
     function GetY2AxisTitle(): UTF8String;
+    function GetStratumValue(): UTF8String;
   end;
 
   IChartTitleConfiguration = interface(IChartTitles)['{4DCBD46E-C9EB-46A4-9313-7B3C943F7B82}']
@@ -22,6 +23,7 @@ type
     function SetXAxisTitle(Text: UTF8String): IChartTitleConfiguration;
     function SetYAxisTitle(Text: UTF8String): IChartTitleConfiguration;
     function SetY2AxisTitle(Text: UTF8String): IChartTitleConfiguration;
+    function SetStratumValue(Text: UTF8String): IChartTitleConfiguration;
   end;
 
 implementation

--- a/src/graph/graphcommandexecutor.pas
+++ b/src/graph/graphcommandexecutor.pas
@@ -71,7 +71,7 @@ begin
     if (ST.HasOption(['sizey', 'sy'], Opt)) then
       SaveAction.GraphSize.Height := Opt.Expr.AsInteger;
 
-    if SaveAction.Execute then
+    if SaveAction.SaveGraphs() then
       FOutputCreator.DoInfoAll('Graph saved as: ' + SaveAction.Filename)
     else
       FOutputCreator.DoError('Graph not saved!');

--- a/src/graph/graphform/graphform.impl.pas
+++ b/src/graph/graphform/graphform.impl.pas
@@ -27,7 +27,7 @@ type
 implementation
 
 uses
-  Controls, TAGraph, charttitles, chartpair;
+  Controls, TAGraph, charttitles, chartpair, savegraphaction;
 
 { TGraphForm }
 
@@ -57,6 +57,7 @@ var
   Sheet: TTabSheet;
 //  Titles: IChartTitles;
   Chart: TChart;
+  saveName: UTF8String;
   i, count: Integer;
   s: UTF8String;
 begin
@@ -66,7 +67,7 @@ begin
     begin
       Inc(count);
       Chart := Pair.Chart;
-
+      FSaveGraphAction.AddChart(Chart, Pair.Configuration.GetTitleConfiguration().GetStratumValue);
       Sheet := FPageControl.AddTabSheet;
       Sheet.Caption := 'Chart: ' + IntToStr(FPageControl.PageCount);
       Chart.Parent := Sheet;
@@ -81,11 +82,6 @@ begin
   if (count > 1) then
     FPageControl.ShowTabs := (Pair.InstanceSize > 1);
 
-  // TODO: Saving multiple charts from FPageControl
-  //       SaveGraphAction must work on the PageControl, not the Charts!
-  //       It can loop through the tabs
-  //       or each Chart must have its own SaveGraphAction...
-  FSaveGraphAction.Chart := ChartPairs.First.Chart;
 end;
 
 function TGraphForm.GetForm: TCustomForm;

--- a/src/graph/graphform/savegraphdialogaction.pas
+++ b/src/graph/graphform/savegraphdialogaction.pas
@@ -19,7 +19,7 @@ type
     procedure SaveGraphExecute(Sender: TObject); override;
   public
     constructor Create(AOwner: TComponent); override;
-    property Chart;
+    property ChartCount;
   end;
 
 implementation
@@ -31,7 +31,7 @@ uses
 
 procedure TSaveGraphDialogAction.UpdateReadyState();
 begin
-  Enabled := Assigned(Chart);
+  Enabled := (ChartCount > 0);
 end;
 
 procedure TSaveGraphDialogAction.SaveGraphExecute(Sender: TObject);

--- a/src/graph/savegraphaction.pas
+++ b/src/graph/savegraphaction.pas
@@ -5,7 +5,7 @@ unit savegraphaction;
 interface
 
 uses
-  Classes, SysUtils, ActnList, TAGraph, Graphics, Types;
+  Classes, SysUtils, ActnList, TAGraph, Graphics, Types, ChartPair;
 
 type
 
@@ -23,7 +23,18 @@ const
     '.png',
     '.jpg'
   );
-
+  // invalid characters in filenames for each OS
+  InvalidChars: TSysCharSet = [
+  {$IFDEF WINDOWS}
+  '<','>',':','"','/','\','|','?','*'
+  {$ENDIF}
+  {$IFDEF DARWIN}
+  ':','/'
+  {$ENDIF}
+  {$IFDEF LINUX}
+  '/'
+  {$ENDIF}
+  ];
 type
 
   EIncorrectGraphExtension = class(Exception);
@@ -32,37 +43,44 @@ type
 
   TCustomSaveGraphAction = class(TCustomAction)
   private
-    FChart: TChart;
-    FFilename: UTF8String;
+    FCharts: array of TChart;
+    FCount: Integer;
+    FStratumValues: array of UTF8String;
+    FFileName: UTF8String;
     FExtensionOK: Boolean;
     FGraphExportType: TGraphExportType;
     FGraphSize: TSize;
-    procedure SaveToRaster(ImageClass: TRasterImageClass);
-    procedure SaveToVector();
-    procedure SetChart(AValue: TChart);
+    procedure SaveToRaster(ImageClass: TRasterImageClass; Filename: UTF8String);
+    procedure SaveToVector(Filename: UTF8String);
     procedure SetFilename(AValue: UTF8String);
     procedure UpdateExportType();
   protected
     procedure UpdateReadyState(); virtual;
     procedure SaveGraphExecute(Sender: TObject); virtual;
-    property Chart: TChart read FChart write SetChart;
-    property Filename: UTF8String read FFilename write SetFilename;
+    property Filename: UTF8String read FFilename write setFilename;
+    property ChartCount: Integer read FCount;
     property GraphExportType: TGraphExportType read FGraphExportType write FGraphExportType;
     property GraphSize: TSize read FGraphSize write FGraphSize;
     property ExtensionOK: Boolean read FExtensionOK write FExtensionOK;
   public
     constructor Create(AOwner: TComponent); override;
+    procedure AddChart(AChart: TChart; AText: UTF8String);
     function SaveGraphs(): Boolean;
     destructor Destroy; override;
   end;
 
+  {TSaveGraphAction}
+
   TSaveGraphAction = class(TCustomSaveGraphAction)
   public
-    property Chart;
+    property ChartCount;
+    property FileName;
     property GraphExportType;
-    property Filename;
     property GraphSize;
   end;
+
+  {helper function}
+  function GetSaveChartFilename(AFileName: UTF8String; AValue: UTF8String): UTF8String;
 
 implementation
 
@@ -72,16 +90,16 @@ uses
 { TSaveGraphAction }
 
 // when invoked here by graphCommandExecutor
-// must have set Filename for every chart before calling
+// must have set Filename for the set of charts before calling
 function TCustomSaveGraphAction.SaveGraphs(): Boolean;
 begin
   result := FExtensionOK;
   if (not FExtensionOK) then
     exit;
   case GraphExportType of
-    etSVG: SaveToVector();
-    etPNG: SaveToRaster(TPortableNetworkGraphic);
-    etJPG: SaveToRaster(TJPEGImage);
+    etSVG: SaveToVector(FFileName);
+    etPNG: SaveToRaster(TPortableNetworkGraphic, FFileName);
+    etJPG: SaveToRaster(TJPEGImage, FFileName);
     else
       result := false;
   end;
@@ -93,10 +111,13 @@ begin
   SaveGraphs();
 end;
 
-procedure TCustomSaveGraphAction.SetChart(AValue: TChart);
+procedure TCustomSaveGraphAction.AddChart(AChart: TChart; AText: UTF8String);
 begin
-  if FChart = AValue then Exit;
-  FChart := AValue;
+  inc(FCount);
+  setLength(FCharts, FCount);
+  FCharts[FCount - 1] := AChart;
+  setLength(FStratumValues, FCount);
+  FStratumValues[FCount - 1] := AText;
 
   UpdateReadyState();
 end;
@@ -105,7 +126,6 @@ procedure TCustomSaveGraphAction.SetFilename(AValue: UTF8String);
 begin
   if FFilename = AValue then Exit;
   FFilename := ExpandFileNameUTF8(AValue);
-
   UpdateExportType();
   UpdateReadyState();
 end;
@@ -134,22 +154,32 @@ end;
 procedure TCustomSaveGraphAction.UpdateReadyState();
 begin
   Enabled := (FFilename <> '') and
-             (Assigned(FChart));
+             (FCount > 0);
 end;
 
-procedure TCustomSaveGraphAction.SaveToRaster(ImageClass: TRasterImageClass);
+procedure TCustomSaveGraphAction.SaveToRaster(ImageClass: TRasterImageClass;
+  Filename: UTF8String);
 var
   Image: TRasterImage;
+  aChart: TChart;
+  i: integer;
 begin
-  Image := ImageClass.Create;
-  Image.Width := FGraphSize.Width;
-  Image.Height := FGraphSize.Height;
-  FChart.PaintOnCanvas(Image.Canvas, Rect(0, 0, Image.Width, Image.Height));
-  Image.SaveToFile(Filename);
-  Image.Free;
+  for i := 0 to FCount - 1 do
+  begin
+    achart := FCharts[i];
+    Image := ImageClass.Create;
+    Image.Width := FGraphSize.Width;
+    Image.Height := FGraphSize.Height;
+    aChart.PaintOnCanvas(Image.Canvas, Rect(0, 0, Image.Width, Image.Height));
+    Image.SaveToFile(GetSaveChartFilename(FFilename, FStratumValues[i]));
+    Image.Free;
+  end;
 end;
 
-procedure TCustomSaveGraphAction.SaveToVector();
+procedure TCustomSaveGraphAction.SaveToVector(Filename: UTF8String);
+var
+  aChart: TChart;
+  i: integer;
 begin
   {$IFDEF DARWIN}
   // this is necessary to save to SVG, but causes font exceptions
@@ -157,9 +187,13 @@ begin
   // No impact for users.
   InitFonts('/System/Library/Fonts');
   {$ENDIF}
-  FChart.Width  := FGraphSize.Width;
-  FChart.Height := FGraphSize.Height;
-  FChart.SaveToSVGFile(FileName);
+  for i := 0 to FCount - 1 do
+    begin
+      aChart := FCharts[i];
+      aChart.Width := FGraphSize.Width;
+      aChart.Height:= FGraphSize.Height;
+      aChart.SaveToSVGFile(GetSaveChartFilename(FFilename, FStratumValues[i]));
+    end;
 end;
 
 constructor TCustomSaveGraphAction.Create(AOwner: TComponent);
@@ -168,14 +202,44 @@ begin
   FGraphSize := TSize.Create(1024, 768);
   OnExecute := @SaveGraphExecute;
   Caption := 'Save as ...';
+  FCount := 0;
 end;
 
 destructor TCustomSaveGraphAction.Destroy;
+var
+  i: integer;
 begin
-  // remove chart before freeing
-  RemoveComponent(FChart);
+  // remove charts before freeing
+  for i := 0 to high(FCharts) do
+    RemoveComponent(FCharts[i]);
   inherited Destroy;
 end;
+
+// create a save file name from base name and optional text, which should be stratum value (not label)
+function GetSaveChartFilename(AFileName: UTF8String; AValue: UTF8String): UTF8String;
+var
+  ext,
+  qual: UTF8String;
+  aChar: Char;
+  i: Integer;
+begin
+  result := AFileName;
+  if (AValue = '') then
+    exit;
+  ext := ExtractFileExt(AFileName);
+  // remove illegal characters in AValue based on OS (see InvalidChars def above)
+  qual := '';
+  for aChar in AValue do
+    if CharInSet(aChar, InvalidChars) then
+      qual += '-'
+    else
+      qual += aChar;
+  // insert clean AValue before extension
+  qual := '-' + qual;
+  insert(qual, AFileName, pos(ext, AFileName));
+  result := AFileName;
+end;
+
 
 end.
 


### PR DESCRIPTION
Sorry, there's no point in breaking this down as it all has to fit together.

### savegraphaction

- FChart becomes an array of charts
- FStratumValues holds the stratum names
- SaveTo procedures must get the composed file name along with the chart
- ChartCount >0 indicates that charts have been loaded
- AddChart replaces SetChart; this is where the stratum value is provided
- SaveTo procedures must loop through the charts and customize file names
- Helper function GetSaveChartFilename provides the actual file name used. If there are no strata, this is simply the filename provided by the user or chart command. If there are strata, then the stratum value must be checked for invalid characters. Then -stratumValue is inserted in the filename right before the .extension.

### savegraphdialogaction

- queries ChartCount to know if there are charts

### graphform.impl

- adds each chart, getting the stratum value from the chartconfiguration object

### graphcommandexecutor

- must work with chartPairs, not just a single chart, since the chartconfiguration object has the stratum value
- there are loops to process all of the charts created by the chart command