### PR TITLE
Changes to make Help work when testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ src/grammar/*.log
 ppas.sh
 src/grammar/buildgrammer.sh
 validator
+help/commands.html

--- a/src/executor/executor.pas
+++ b/src/executor/executor.pas
@@ -1936,12 +1936,7 @@ begin
   FOptions.Insert(ANA_SO_INCLUDE_DELETED, TSetOption.Create('OFF', rtBoolean));
 
   FOptions.Insert(ANA_SO_TUTORIAL_FOLDER,
-    TFolderOption.Create({$IFDEF DARWIN}
-                        ResolveDots(ProgramDirectory + '../../../docs')
-                      {$ELSE}
-                        ProgramDirectory + 'docs'
-                      {$ENDIF},
-                      rtString));
+    TFolderOption.Create(ProgramDirectory + 'docs',rtString));
   // STATISTICS
   SOpt := TSetOption.Create('95', rtInteger);
   SOpt.LegalValues.Add('90');

--- a/src/main/main.pas
+++ b/src/main/main.pas
@@ -528,8 +528,9 @@ begin
   FStatusbar.Parent := Self;
   FStatusbar.Align := alBottom;
   FStatusbar.Update(sucDocFile);
+  // Why do we do this for Darwin here?
   {$IFDEF DARWIN}
-  SetCurrentDirUTF8(ResolveDots(ProgramDirectory + '../../..'));
+  SetCurrentDirUTF8(ProgramDirectoryWithBundle);
   {$ENDIF}
 
   {$IFNDEF LINUX}


### PR DESCRIPTION
Main: proper way to get MacOS program directory
Executor: Don't seem to need this any more to get to help file, perhaps because ProgramDirectory was set in Main?