### PR TITLE
Jamie/graph command should fail if no data

### DIFF
--- a/src/executor/executor.pas
+++ b/src/executor/executor.pas
@@ -3009,8 +3009,7 @@ begin
   ST.ExecResult := csrFailed;
   try
     DoStatement(ST.Statement);
-//  ExecResult for the select will be that of the statement executed
-//    ST.ExecResult := csrSuccess;
+    ST.ExecResult := csrSuccess;
   finally
     F := FSelectStack.Pop;
     F.RemoveCustomData(SELECTION_EXPR);

--- a/src/executor/executor.pas
+++ b/src/executor/executor.pas
@@ -3009,7 +3009,8 @@ begin
   ST.ExecResult := csrFailed;
   try
     DoStatement(ST.Statement);
-    ST.ExecResult := csrSuccess;
+//  ExecResult for the select will be that of the statement executed
+//    ST.ExecResult := csrSuccess;
   finally
     F := FSelectStack.Pop;
     F.RemoveCustomData(SELECTION_EXPR);

--- a/src/graph/commands/barchart/barchart.pas
+++ b/src/graph/commands/barchart/barchart.pas
@@ -79,6 +79,7 @@ var
   yType:               UTF8String;
   msg:                 UTF8String;
 begin
+  Command.ExecResult := csrFailed;
   VariableLabelOutput := VariableLabelTypeFromOptionList(Command.Options, FExecutor.SetOptions);
   ValueLabelOutput    := ValueLabelTypeFromOptionList(Command.Options, FExecutor.SetOptions);
   sColor              := ChartColorsFromOptions(Command.Options, FExecutor.SetOptions, msg);
@@ -219,6 +220,7 @@ begin
     VarNames.Free;
     TablesAll.Free;
     T.Free;
+    Command.ExecResult := csrSuccess;
   end; // create chart
   DataFile.Free;
   cOptions.Free;

--- a/src/graph/commands/epicurve/epicurve.pas
+++ b/src/graph/commands/epicurve/epicurve.pas
@@ -80,6 +80,7 @@ var
   msg:                 UTF8String;
 
 begin
+  Command.ExecResult := csrFailed;
   VariableLabelOutput := VariableLabelTypeFromOptionList(Command.Options, FExecutor.SetOptions);
   ValueLabelOutput    := ValueLabelTypeFromOptionList(Command.Options, FExecutor.SetOptions);
   sColor              := ChartColorsFromOptions(Command.Options, FExecutor.SetOptions, msg);
@@ -224,6 +225,7 @@ begin
     VarNames.Free;
     TablesAll.Free;
     T.Free;
+    Command.ExecResult := csrSuccess;
   end;
   DataFile.Free;
   StratVariable.Free;

--- a/src/graph/commands/histogram/histogram.pas
+++ b/src/graph/commands/histogram/histogram.pas
@@ -79,6 +79,7 @@ var
   yType:               UTF8String;
   msg:                 UTF8String;
 begin
+  Command.ExecResult := csrFailed;
   VariableLabelOutput := VariableLabelTypeFromOptionList(Command.Options, FExecutor.SetOptions);
   ValueLabelOutput    := ValueLabelTypeFromOptionList(Command.Options, FExecutor.SetOptions);
   sColor              := ChartColorsFromOptions(Command.Options, FExecutor.SetOptions, msg);
@@ -217,6 +218,7 @@ begin
     VarNames.Free;
     TablesAll.Free;
     T.Free;
+    Command.ExecResult := csrSuccess;
   end;
   DataFile.Free;
   StratVariable.Free;

--- a/src/graph/commands/pareto/pareto.pas
+++ b/src/graph/commands/pareto/pareto.pas
@@ -76,6 +76,7 @@ var
   StratChartIndex:     UTF8String;
   i:                   Integer;
 begin
+  Command.ExecResult   := csrFailed;
   FVariableLabelOutput := VariableLabelTypeFromOptionList(Command.Options, FExecutor.SetOptions);
   FValueLabelOutput    := ValueLabelTypeFromOptionList(Command.Options, FExecutor.SetOptions);
   FColor               := ChartColorsFromOptions(Command.Options, FExecutor.SetOptions, msg);
@@ -166,6 +167,7 @@ begin
       TablesAll.Free;
       XVar.Free;
       dummyVar.Free;
+      Command.ExecResult := csrSuccess;
     end;  // create charts
 
   StratifyVarNames.Free;

--- a/src/graph/commands/scatter/scatter.pas
+++ b/src/graph/commands/scatter/scatter.pas
@@ -52,6 +52,7 @@ var
   sPoints, sLine: Boolean;
   msg: UTF8String;
 begin
+  Command.ExecResult := csrFailed;
   sColor := ChartColorsFromOptions(Command.Options, FExecutor.SetOptions, msg);
   if (msg <> '') then
   begin
@@ -66,69 +67,73 @@ begin
   // Get the data and fields.
   DataFile := FExecutor.PrepareDatafile(VarNames, VarNames);
   if (DataFile.Size < 1) then
-    FExecutor.Error('No data')
-  else
-  begin
-    Chart := FChartFactory.NewChart();
-    XVar := Datafile.Fields.FieldByName[VarNames[0]];
-    YVar := Datafile.Fields.FieldByName[Varnames[1]];
-    DataFile.SortRecords(XVar);
-    Varnames.Free;
+    begin
+      DataFile.Free;
+      FExecutor.Error('No data');
+      exit;
+    end;
 
-    // Create our own datasource
-    // - datasource is destroyed by the chart, so we let it handle the datafile destruction
-    //   otherwise we would leak memory.
-    ScatterSource := TScatterSource.Create(Chart);
-    ScatterSource.Datafile := DataFile;
-    ScatterSource.XVariableName := XVar.Name;
-    ScatterSource.YVariableName := YVar.Name;
-    ScatterSource.Sorted := true;
+  Chart := FChartFactory.NewChart();
+  XVar := Datafile.Fields.FieldByName[VarNames[0]];
+  YVar := Datafile.Fields.FieldByName[Varnames[1]];
+  DataFile.SortRecords(XVar);
+  Varnames.Free;
 
-    // Get options
+  // Create our own datasource
+  // - datasource is destroyed by the chart, so we let it handle the datafile destruction
+  //   otherwise we would leak memory.
+  ScatterSource := TScatterSource.Create(Chart);
+  ScatterSource.Datafile := DataFile;
+  ScatterSource.XVariableName := XVar.Name;
+  ScatterSource.YVariableName := YVar.Name;
+  ScatterSource.Sorted := true;
 
-    sLine := Command.HasOption('l');
-    sPoints := (not Command.HasOption('l')) or Command.HasOption('p');
+  // Get options
 
-    // Create the line/point series
-    LineSeries := TLineSeries.Create(Chart);
-    with LineSeries do
+  sLine := Command.HasOption('l');
+  sPoints := (not Command.HasOption('l')) or Command.HasOption('p');
+
+  // Create the line/point series
+  LineSeries := TLineSeries.Create(Chart);
+  with LineSeries do
+    begin
+      Source := ScatterSource;
+      ShowPoints := sPoints;
+      if (sPoints) then
       begin
-        Source := ScatterSource;
-        ShowPoints := sPoints;
-        if (sPoints) then
-        begin
-          Pointer.Pen.Color := sColor[0];
-          Pointer.Style := psCircle;
-          Linetype := ltNone;
-        end;
-        if (Sline) then
-        begin
-          LineType := ltFromPrevious;
-          LinePen.Color:= sColor[0];
-        end;
+        Pointer.Pen.Color := sColor[0];
+        Pointer.Style := psCircle;
+        Linetype := ltNone;
       end;
-    // Add series to the chart
-    Chart.AddSeries(LineSeries);
+      if (Sline) then
+      begin
+        LineType := ltFromPrevious;
+        LinePen.Color:= sColor[0];
+      end;
+    end;
+  // Add series to the chart
+  Chart.AddSeries(LineSeries);
 
-    // Create the titles
-    VariableLabelType := VariableLabelTypeFromOptionList(Command.Options, FExecutor.SetOptions, sovStatistics);
-    ChartConfiguration := FChartFactory.NewChartConfiguration();
-    ChartConfiguration.GetTitleConfiguration()
-      .SetTitle(XVar.GetVariableLabel(VariableLabelType) + ' vs. ' + YVar.GetVariableLabel(VariableLabelType))
-      .SetFootnote('')
-      .SetXAxisTitle(XVar.GetVariableLabel(VariableLabelType))
-      .SetYAxisTitle(YVar.GetVariableLabel(VariableLabelType));
+  // Create the titles
+  VariableLabelType := VariableLabelTypeFromOptionList(Command.Options, FExecutor.SetOptions, sovStatistics);
+  ChartConfiguration := FChartFactory.NewChartConfiguration();
+  ChartConfiguration.GetTitleConfiguration()
+    .SetTitle(XVar.GetVariableLabel(VariableLabelType) + ' vs. ' + YVar.GetVariableLabel(VariableLabelType))
+    .SetFootnote('')
+    .SetXAxisTitle(XVar.GetVariableLabel(VariableLabelType))
+    .SetYAxisTitle(YVar.GetVariableLabel(VariableLabelType));
 
-    ChartConfiguration.GetAxesConfiguration()
-      .GetXAxisConfiguration()
-      .SetShowAxisMarksAsDates(XVar.FieldType in DateFieldTypes);
+  ChartConfiguration.GetAxesConfiguration()
+    .GetXAxisConfiguration()
+    .SetShowAxisMarksAsDates(XVar.FieldType in DateFieldTypes);
 
-    ChartConfiguration.GetAxesConfiguration()
-      .GetYAxisConfiguration()
-      .SetShowAxisMarksAsDates(YVar.FieldType in DateFieldTypes);
+  ChartConfiguration.GetAxesConfiguration()
+    .GetYAxisConfiguration()
+    .SetShowAxisMarksAsDates(YVar.FieldType in DateFieldTypes);
 
-    Result.AddChart(Chart, ChartConfiguration);
-  end;
+  Result.AddChart(Chart, ChartConfiguration);
+  Command.ExecResult := csrSuccess;
+
 end;
 
 initialization


### PR DESCRIPTION
Graph command must consistently return success or failed for assert to be useful.
Graphs commands should fail if no data or if some other error occurs.
Currently, only survival returns a useful result, so this implements it for other graphs.
Also found that select (condition) do command always returned csrSuccess.
With the change to executor, select result is that of the command.